### PR TITLE
Iframe resizer multiple firing fix

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,5 +3,6 @@ Name: nswdpc-elemental-iframe
 ---
 NSWDPC\Elemental\Models\Iframe\ElementIframe:
   load_polyfill: true
+  resizer_log: false
   default_allow_attributes:
       - 'fullscreen'

--- a/templates/NSWDPC/Elemental/Models/Iframe/ElementIframe.ss
+++ b/templates/NSWDPC/Elemental/Models/Iframe/ElementIframe.ss
@@ -1,10 +1,10 @@
 <div class="content-element__content<% if $StyleVariant %> {$StyleVariant}<% end_if %>">
     <% include ElementIframeTitle %>
-<div class="outer<% if $IsResponsive %> responsive-iframe is-{$IsResponsive.XML}<% end_if %>">
+<div class="outer<% if $IsDynamic %> iframe-resizer<% end_if %><% if $IsResponsive %> responsive-iframe is-{$IsResponsive.XML}<% end_if %>">
         <% if $IsLazy %><noscript class="loading-lazy"><% end_if %>
             <iframe
                 <% if $AlternateContent %>title="{$AlternateContent.XML}"<% end_if %>
-                <% if $IsResponsive %>class="responsive-item"<% end_if %>
+                class="<% if $IsResponsive %> responsive-item<% end_if %>"
                 width="{$IframeWidth.XML}"
                 height="{$IframeHeight.XML}"
                 id="{$Anchor.XML}-frame"


### PR DESCRIPTION
## Changes

+ Fix: fire iframe resizer on window.load for all iframes matching the selector.
+ Modify field description text to make the options more understandable and when they may clash with each other.
+ Hide iframeResize() log behind a configuration variable