### PR TITLE
Fix: polyfill check

### DIFF
--- a/src/Models/Elements/ElementIframe.php
+++ b/src/Models/Elements/ElementIframe.php
@@ -465,4 +465,11 @@ JAVASCRIPT;
         return $fields;
     }
 
+    /**
+     * Return whether lazy load polyfill is enabled, useful in templates
+     */
+    public function HasPolyfill(): bool {
+        return (bool)self::config()->get('load_polyfill');
+    }
+
 }

--- a/templates/NSWDPC/Elemental/Models/Iframe/ElementIframe.ss
+++ b/templates/NSWDPC/Elemental/Models/Iframe/ElementIframe.ss
@@ -1,7 +1,7 @@
 <div class="content-element__content<% if $StyleVariant %> {$StyleVariant}<% end_if %>">
     <% include ElementIframeTitle %>
 <div class="outer<% if $IsDynamic %> iframe-resizer<% end_if %><% if $IsResponsive %> responsive-iframe is-{$IsResponsive.XML}<% end_if %>">
-        <% if $IsLazy %><noscript class="loading-lazy"><% end_if %>
+        <% if $IsLazy && $HasPolyfill %><noscript class="loading-lazy"><% end_if %>
             <iframe
                 <% if $AlternateContent %>title="{$AlternateContent.XML}"<% end_if %>
                 class="<% if $IsResponsive %> responsive-item<% end_if %>"
@@ -13,6 +13,6 @@
                 src="{$URL.LinkURL.XML}"
                 frameborder="0">
             </iframe>
-        <% if $IsLazy %></noscript><% end_if %>
+        <% if $IsLazy && $HasPolyfill %></noscript><% end_if %>
     </div>
 </div>


### PR DESCRIPTION
## Changes

+ Fix a bug where if the polyfill was turned off and lazy loading was turned on, the template would still render the <noscript>. It should only render the noscript tag when lazy loading is on AND the polyfill is enabled.

This is a cherry-pick of https://github.com/nswdpc/silverstripe-elemental-iframe/commit/2087c04a29559c42df66bdbb96c3ef88675ab555 onto the v0-3 branch